### PR TITLE
Unicorn設定の編集

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -40,3 +40,7 @@ end
 after_fork do |_server, _worker|
   defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
 end
+
+before_exec do |server|
+  ENV['BUNDLE_GEMFILE'] = @app_path + "/current/Gemfile"
+end


### PR DESCRIPTION
# WHAT
unicorn.rbの編集

# WHY
デプロイでエラー発生
unicornがGemfileの場所を見つけられていないので明示的に変更する。